### PR TITLE
fix: import Link components

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { supabase } from '../lib/supabase';
 import { products } from '../stripe-config';
 import { Alert } from '../components/Alert';
+import { Link } from 'react-router-dom';
 
 interface Subscription {
   subscription_status: string;

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { products } from '../stripe-config';
 import { Alert } from '../components/Alert';


### PR DESCRIPTION
## Summary
- import Link from react-router-dom in Dashboard
- remove unused Link import from Pricing

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f4ccb128832aa18623b58da3fe94