### PR TITLE
fix: use absolute path for favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet">
-    <link rel="icon" type="image/png" href="./favicon.png" />
+    <link rel="icon" type="image/png" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>StageCue - Professional Event Timing</title>
   </head>


### PR DESCRIPTION
## Summary
- fix relative favicon link to use absolute path to site root

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'isValidResetSession' and 'searchParams' are assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_68b61c76da1c832abf15fa056b4e2684