### PR TITLE
Improve Stripe checkout success flow

### DIFF
--- a/src/components/SignUpModal.tsx
+++ b/src/components/SignUpModal.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { products } from '../stripe-config';
 import { Alert } from './Alert';
+import { supabase } from '../lib/supabase';
 
 interface SignUpModalProps {
   isOpen: boolean;
@@ -39,12 +40,22 @@ export function SignUpModal({ isOpen, onClose, defaultPlan }: SignUpModalProps) 
         throw new Error('Selected plan not found');
       }
 
+      // Get the authenticated session for the newly created user
+      const {
+        data: { session },
+        error: sessionError,
+      } = await supabase.auth.getSession();
+
+      if (sessionError || !session) {
+        throw new Error('Unable to retrieve session after sign up');
+      }
+
       // Create Stripe checkout session
       const response = await fetch(`${import.meta.env.VITE_SUPABASE_URL}/functions/v1/stripe-checkout`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY}`,
+          Authorization: `Bearer ${session.access_token}`,
         },
         body: JSON.stringify({
           price_id: selectedProduct.priceId,

--- a/src/pages/GetStarted.tsx
+++ b/src/pages/GetStarted.tsx
@@ -45,7 +45,7 @@ export function GetStarted() {
         },
         body: JSON.stringify({
           price_id: selectedProduct.priceId,
-          success_url: `${window.location.origin}/dashboard`,
+          success_url: `${window.location.origin}/success`,
           cancel_url: `${window.location.origin}/get-started`,
           mode: selectedProduct.mode,
           trial_period_days: 7,

--- a/src/pages/Success.tsx
+++ b/src/pages/Success.tsx
@@ -1,24 +1,26 @@
-import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { Alert } from '../components/Alert';
+import { supabase } from '../lib/supabase';
 
 export function Success() {
-  const [countdown, setCountdown] = useState(5);
+  const navigate = useNavigate();
 
   useEffect(() => {
-    const timer = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) {
-          clearInterval(timer);
-          window.location.href = '/dashboard';
-          return 0;
-        }
-        return prev - 1;
-      });
+    const interval = setInterval(async () => {
+      const { data } = await supabase
+        .from('stripe_user_subscriptions')
+        .select('subscription_status')
+        .maybeSingle();
+
+      if (data?.subscription_status === 'trialing' || data?.subscription_status === 'active') {
+        clearInterval(interval);
+        navigate('/dashboard');
+      }
     }, 1000);
 
-    return () => clearInterval(timer);
-  }, []);
+    return () => clearInterval(interval);
+  }, [navigate]);
 
   return (
     <div className="min-h-screen bg-gray-50 flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
@@ -43,13 +45,11 @@ export function Success() {
             Payment Successful!
           </h2>
           <p className="mt-2 text-sm text-gray-600">
-            Thank you for your purchase. Your subscription is now active.
+            Finalizing your subscription...
           </p>
         </div>
 
-        <Alert type="success">
-          Redirecting to dashboard in {countdown} seconds...
-        </Alert>
+        <Alert type="success">This may take a few seconds.</Alert>
 
         <div className="space-y-4">
           <Link

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -127,6 +127,20 @@ async function handleEvent(event: Stripe.Event) {
 // based on the excellent https://github.com/t3dotgg/stripe-recommendations
 async function syncCustomerFromStripe(customerId: string) {
   try {
+    // ensure we have a mapping between Stripe customer and user
+    const stripeCustomer = (await stripe.customers.retrieve(customerId)) as Stripe.Customer;
+    const userId = stripeCustomer.metadata?.userId;
+
+    if (userId) {
+      const { error: customerMapError } = await supabase.from('stripe_customers').upsert(
+        { user_id: userId, customer_id: customerId },
+        { onConflict: 'user_id' },
+      );
+      if (customerMapError) {
+        console.error('Error saving customer mapping:', customerMapError);
+      }
+    }
+
     // fetch latest subscription data from Stripe
     const subscriptions = await stripe.subscriptions.list({
       customer: customerId,


### PR DESCRIPTION
## Summary
- Use authenticated session token when creating Stripe checkout during sign-up
- Redirect trial signup to `/success` and wait for subscription sync before navigating
- Ensure Stripe webhook links customers to users and updates subscription mapping

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b635b96078832a906a7ec352bcb36a